### PR TITLE
Overwrite config by env

### DIFF
--- a/helpers/config.go
+++ b/helpers/config.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strconv"
 	"time"
 )
 
@@ -38,6 +40,9 @@ func LoadConfig() Config {
 	if loadedConfig == nil {
 		loadedConfig = loadConfigJsonFromPath()
 	}
+
+	// overwrite config by env
+	readEnv("", reflect.ValueOf(loadedConfig))
 
 	if loadedConfig.ApiEndpoint == "" {
 		panic("missing configuration 'api'")
@@ -87,4 +92,49 @@ func configPath() string {
 	}
 
 	return path
+}
+
+func readEnv(prefix string, v reflect.Value) {
+	if v.Kind() != reflect.Ptr {
+		panic("not ptr")
+	}
+	value := v.Elem()
+	valueType := value.Type()
+	fieldsCount := valueType.NumField()
+	for i := 0; i < fieldsCount; i++ {
+		field := value.Field(i)
+		fieldName := valueType.Field(i).Name
+		fieldKind := field.Kind()
+		env := os.Getenv(prefix + fieldName)
+		switch fieldKind {
+		case reflect.String:
+			if len(env) == 0 {
+				continue
+			}
+			field.SetString(env)
+		case reflect.Int, reflect.Int64:
+			if len(env) == 0 {
+				continue
+			}
+			val, _ := strconv.ParseInt(env, 0, 64)
+			field.SetInt(val)
+		case reflect.Bool:
+			if len(env) == 0 {
+				continue
+			}
+			val, _ := strconv.ParseBool(env)
+			field.SetBool(val)
+		case reflect.Map:
+			for _, key := range field.MapKeys() {
+				new_value := reflect.New(field.MapIndex(key).Type()).Elem()
+				new_value.Set(field.MapIndex(key))
+				readEnv(prefix+fieldName+"_"+key.String()+"_", new_value.Addr())
+				field.SetMapIndex(key, new_value)
+			}
+		case reflect.Struct:
+			readEnv(prefix+fieldName+"_", field.Addr())
+		default:
+			panic("readProcess undefined. type = " + fieldKind.String())
+		}
+	}
 }


### PR DESCRIPTION
Use environment variables to configure CATs

Motivation:  
When we run CATs, integration_config.json needs to be configured.  
And when we want to set it for another environment, what should we do?  
The simple way is copy integration_config.json and edit it.  
But we don't want to have many config files.

This PR enables override configuraions by environment variables.  
ex)
```
$ cat > integration_config.json <<EOF
{
  "api": "api.10.244.0.34.xip.io",
  "admin_user": "admin",
  "admin_password": "admin",
  "apps_domain": "10.244.0.34.xip.io",
  "skip_ssl_validation": false
}
EOF
$ export CONFIG=$PWD/integration_config.json
$ export SkipSSLValidation=true # skip_ssl_validation is overridden.
$ bin/test
```

Note:  
An environment variable name is based on each attribute definition, not json definition.  
bad: `$ export skip_ssl_validation=true`  
ok: `$ export SkipSSLValidation=true`  