### PR TITLE
Remove unused TimoutScale field from IntegrationConfig

### DIFF
--- a/services/context_setup/integration_config.go
+++ b/services/context_setup/integration_config.go
@@ -1,10 +1,9 @@
 package context_setup
 
 type IntegrationConfig struct {
-	AppsDomain        string  `json:"apps_domain"`
-	ApiEndpoint       string  `json:"api"`
-	AdminUser         string  `json:"admin_user"`
-	AdminPassword     string  `json:"admin_password"`
-	SkipSSLValidation bool    `json:"skip_ssl_validation"`
-	TimeoutScale      float64 `json:"timeout_scale"`
+	AppsDomain        string `json:"apps_domain"`
+	ApiEndpoint       string `json:"api"`
+	AdminUser         string `json:"admin_user"`
+	AdminPassword     string `json:"admin_password"`
+	SkipSSLValidation bool   `json:"skip_ssl_validation"`
 }


### PR DESCRIPTION
It's not used anywhere, and it's quite confusing if you set it and then expect it to have an effect.

The right way to set the timeout scale when using this package is to set the [`context_setup.TimeoutScale`](https://github.com/cloudfoundry-incubator/cf-test-helpers/blob/master/services/context_setup/timeout.go#L7) global, which isn't super nice, but we don't want to break the API of the package so we've not changed that.