### PR TITLE
Add security group creation to context_setup

### DIFF
--- a/services/context_setup/context_setup.go
+++ b/services/context_setup/context_setup.go
@@ -116,6 +116,10 @@ func (context *ConfiguredContext) Teardown() {
 				nil,
 			)
 		}
+
+		if context.config.CreatePermissiveSecurityGroup {
+			Eventually(cf.Cf("delete-security-group", "-f", context.securityGroupName), ScaledTimeout(60*time.Second)).Should(Exit(0))
+		}
 	})
 }
 

--- a/services/context_setup/environment.go
+++ b/services/context_setup/environment.go
@@ -30,13 +30,8 @@ func SetupEnvironment(context SuiteContext) {
 
 		context.Setup()
 
-		cf.AsUser(AdminUserContext, func() {
-			setUpSpaceWithUserAccess(RegularUserContext)
-		})
-
 		originalCfHomeDir, currentCfHomeDir = cf.InitiateUserContext(RegularUserContext)
 		cf.TargetSpace(RegularUserContext)
-
 	})
 
 	AfterEach(func() {

--- a/services/context_setup/integration_config.go
+++ b/services/context_setup/integration_config.go
@@ -1,9 +1,10 @@
 package context_setup
 
 type IntegrationConfig struct {
-	AppsDomain        string `json:"apps_domain"`
-	ApiEndpoint       string `json:"api"`
-	AdminUser         string `json:"admin_user"`
-	AdminPassword     string `json:"admin_password"`
-	SkipSSLValidation bool   `json:"skip_ssl_validation"`
+	AppsDomain                    string `json:"apps_domain"`
+	ApiEndpoint                   string `json:"api"`
+	AdminUser                     string `json:"admin_user"`
+	AdminPassword                 string `json:"admin_password"`
+	CreatePermissiveSecurityGroup bool   `json:"create_permissive_security_group"`
+	SkipSSLValidation             bool   `json:"skip_ssl_validation"`
 }

--- a/services/context_setup/integration_config.go
+++ b/services/context_setup/integration_config.go
@@ -1,10 +1,9 @@
 package context_setup
 
 type IntegrationConfig struct {
-	AppsDomain        string  `json:"apps_domain"`
-	ApiEndpoint       string  `json:"api"`
-	AdminUser         string  `json:"admin_user"`
-	AdminPassword     string  `json:"admin_password"`
-	SkipSSLValidation bool    `json:"skip_ssl_validation"`
-	TimeoutScale      float64 `json:"timeout_scale"`
+	AppsDomain        string `json:"apps_domain"`
+	ApiEndpoint       string `json:"api"`
+	AdminUser         string `json:"admin_user"`
+	AdminPassword     string `json:"admin_password"`
+	SkipSSLValidation bool   `json:"skip_ssl_validation"`
 }


### PR DESCRIPTION
Without this, our test apps can't see our service instances. Not sure why this isn't a problem for the MySQL service, which is currently using this.

We also removed an unused `TimoutScale` field on the `IntegrationConfig` type, having lost a good 20 minutes trying to work out why our tests were timing out immediately!

This change shouldn't break the package for any current users.