### PR TITLE
Updates to allow usage of existing CF users instead of creating new ones

### DIFF
--- a/helpers/config.go
+++ b/helpers/config.go
@@ -14,6 +14,11 @@ type Config struct {
 	AdminUser     string `json:"admin_user"`
 	AdminPassword string `json:"admin_password"`
 
+	UseExistingUser bool `json:"use_existing_user"`
+	ShouldKeepUser bool `json:"keep_user_at_suite_end"`
+	ExistingUser string `json:"existing_user"`
+	ExistingUserPassword string `json:"existing_user_password"`
+
 	PersistentAppHost      string `json:"persistent_app_host"`
 	PersistentAppSpace     string `json:"persistent_app_space"`
 	PersistentAppOrg       string `json:"persistent_app_org"`


### PR DESCRIPTION
Add fields to Config struct to support using an existing CF user instead of generating a new one when the test suite starts and also to support not deleting the user at the end of the test suite run.

Update context to respect settings for using existing user and not deleting the user