### PR TITLE
Add new function to handle stdin and env variables

### DIFF
--- a/helpers/as_intercept_command.go
+++ b/helpers/as_intercept_command.go
@@ -1,0 +1,61 @@
+package helpers
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/runner"
+)
+
+func AsInterceptCommand(stdinString string, env map[string]string, actions func()) {
+	originalCommandInterceptor := runner.CommandInterceptor
+	runner.CommandInterceptor = func(cmd *exec.Cmd) *exec.Cmd {
+		if stdinString != "" {
+			setStdin(cmd, stdinString)
+		}
+		if env != nil {
+			setEnv(cmd, env)
+		}
+		return cmd
+	}
+	defer resetCommandInterceptor(originalCommandInterceptor)
+	actions()
+}
+
+func resetCommandInterceptor(originalCommandInterceptor func(cmd *exec.Cmd) *exec.Cmd) {
+	runner.CommandInterceptor = originalCommandInterceptor
+}
+
+func setStdin(cmd *exec.Cmd, stdinString string) {
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		log.Panic(err)
+	}
+	defer stdin.Close()
+	io.Copy(stdin, bytes.NewBufferString(stdinString))
+}
+
+func setEnv(cmd *exec.Cmd, newEnv map[string]string) {
+	orgEnv := os.Environ()
+	mergedEnvMap := make(map[string]string)
+
+	for _, v := range orgEnv {
+		variables := strings.SplitN(v, "=", 2)
+		orgKey := variables[0]
+		orgValue := variables[1]
+		mergedEnvMap[orgKey] = orgValue
+	}
+
+	for k, v := range newEnv {
+		mergedEnvMap[k] = v
+	}
+
+	for k, v := range mergedEnvMap {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+	}
+}


### PR DESCRIPTION
Currently cf-acceptance-tests/cf-test-helpers cannot handle followings:
- Use STDIN
- Set Environmen variables

This PR is to provide a function which enables such test cases.
Using this function, following test cases can be implemented for cf-acceptance-tests:
- Execute 'cf delete'. You are asked 'Really delete the app?'. Then you type 'yes' or 'no'.
- Execute 'cf push' with CF_STARTUP_TIMEOUT environment variable to confirm the environment variable's behavior.
- Execute various cf commands with CF_TRACE environment variable.

...and so on.

Following examples show how to use this function.

Example 1: Specify environment variable(s)

    env := make(map[string]string)
    env["CF_TRACE"] = "true"
    env["CF_COLOR"] = "false"
    helpers.AsInterceptCommand("", env, func() {
        Expect(cf.Cf("delete", appName, "-f").Wait(DEFAULT_TIMEOUT)).To(Exit(0))
    })

Example 2: Specify STDIN

    helpers.AsInterceptCommand("yes\n", nil, func() {
        Expect(cf.Cf("delete", appName).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
    })

Example 3: Specify both STDIN and environment variable(s)

    env := make(map[string]string)
    env["CF_TRACE"] = "true"
    env["CF_COLOR"] = "false"
    helpers.AsInterceptCommand("yes\n", env, func() {
        Expect(cf.Cf("delete", appName).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
    })

Please note that this function accepts 1 line only for STDIN (at the moment).
Therefore, this function _CANNOT_ be used like below:

    // doesn't work
    helpers.AsInterceptCommand("admin\nadmin\n1\n1\n", nil, func() {
        Expect(cf.Cf("login").Wait(DEFAULT_TIMEOUT)).To(Exit(0))
    })

Any comments to support this or improve code would be appreciated.
