### PR TITLE
Enable use of existing org, space and quota (all or nothing) when running the tests instead of generated entities.

### DIFF
--- a/helpers/config.go
+++ b/helpers/config.go
@@ -22,6 +22,11 @@ type Config struct {
 	ExistingUser         string `json:"existing_user"`
 	ExistingUserPassword string `json:"existing_user_password"`
 
+	UseExistingOrgAndSpace	bool	`json:"use_existing_org_space"`
+	ExistingOrg		string 	`json:"existing_org"`
+	ExistingSpace 	string	`json:"existing_space"`
+	ExistingQuota	string	`json:"existing_quota"`
+
 	PersistentAppHost      string `json:"persistent_app_host"`
 	PersistentAppSpace     string `json:"persistent_app_space"`
 	PersistentAppOrg       string `json:"persistent_app_org"`

--- a/helpers/context.go
+++ b/helpers/context.go
@@ -28,7 +28,8 @@ type ConfiguredContext struct {
 	regularUserUsername string
 	regularUserPassword string
 
-	isPersistent bool
+	isPersistentApp bool
+	isPersistentOrgAndSpace bool
 }
 
 type quotaDefinition struct {
@@ -47,10 +48,21 @@ func NewContext(config Config) *ConfiguredContext {
 
 	regUser := fmt.Sprintf("CATS-USER-%d-%s", node, timeTag)
 	regUserPass := "meow"
+	orgName := fmt.Sprintf("CATS-ORG-%d-%s", node, timeTag)
+	spaceName := fmt.Sprintf("CATS-SPACE-%d-%s", node, timeTag)
+	quota := fmt.Sprintf("CATS-QUOTA-%d-%s", node, timeTag)
+	persistOrgAndSpace := false
 
 	if config.UseExistingUser {
 		regUser = config.ExistingUser
 		regUserPass = config.ExistingUserPassword
+	}
+
+	if config.UseExistingOrgAndSpace {
+		orgName = config.ExistingOrg
+		spaceName = config.ExistingSpace
+		quota = config.ExistingQuota
+		persistOrgAndSpace = true
 	}
 
 	return &ConfiguredContext{
@@ -59,15 +71,16 @@ func NewContext(config Config) *ConfiguredContext {
 		shortTimeout: config.ScaledTimeout(1 * time.Minute),
 		longTimeout:  config.ScaledTimeout(5 * time.Minute),
 
-		quotaDefinitionName: fmt.Sprintf("CATS-QUOTA-%d-%s", node, timeTag),
+		quotaDefinitionName: quota,
 
-		organizationName: fmt.Sprintf("CATS-ORG-%d-%s", node, timeTag),
-		spaceName:        fmt.Sprintf("CATS-SPACE-%d-%s", node, timeTag),
+		organizationName: orgName,
+		spaceName:        spaceName,
 
 		regularUserUsername: regUser,
 		regularUserPassword: regUserPass,
 
-		isPersistent: false,
+		isPersistentApp: false,
+		isPersistentOrgAndSpace: persistOrgAndSpace,
 	}
 }
 
@@ -77,7 +90,7 @@ func NewPersistentAppContext(config Config) *ConfiguredContext {
 	baseContext.quotaDefinitionName = config.PersistentAppQuotaName
 	baseContext.organizationName = config.PersistentAppOrg
 	baseContext.spaceName = config.PersistentAppSpace
-	baseContext.isPersistent = true
+	baseContext.isPersistentApp = true
 
 	return baseContext
 }
@@ -90,30 +103,40 @@ func (context ConfiguredContext) LongTimeout() time.Duration {
 	return context.longTimeout
 }
 
+func (context ConfiguredContext) IsPersistentOrgAndSpace() bool {
+	return context.isPersistentOrgAndSpace
+}
+
 func (context *ConfiguredContext) Setup() {
-	cf.AsUser(context.AdminUserContext(), context.shortTimeout, func() {
-		definition := quotaDefinition{
-			Name: context.quotaDefinitionName,
+	if !context.isPersistentOrgAndSpace {
+		cf.AsUser(context.AdminUserContext(), context.shortTimeout, func() {
+			definition := quotaDefinition {
+				Name: context.quotaDefinitionName,
 
-			TotalServices: "100",
-			TotalRoutes:   "1000",
-			MemoryLimit:   "10G",
+				TotalServices: "100",
+				TotalRoutes:   "1000",
+				MemoryLimit:   "10G",
 
-			NonBasicServicesAllowed: true,
-		}
+				NonBasicServicesAllowed: true,
+			}
 
-		args := []string{
-			"create-quota",
-			context.quotaDefinitionName,
-			"-m", definition.MemoryLimit,
-			"-r", definition.TotalRoutes,
-			"-s", definition.TotalServices,
-		}
-		if definition.NonBasicServicesAllowed {
-			args = append(args, "--allow-paid-service-plans")
-		}
+			args := []string {
+				"create-quota",
+				context.quotaDefinitionName,
+				"-m", definition.MemoryLimit,
+				"-r", definition.TotalRoutes,
+				"-s", definition.TotalServices,
+			}
 
-		runner.NewCmdRunner(cf.Cf(args...), context.shortTimeout).Run()
+			if definition.NonBasicServicesAllowed {
+				args = append(args, "--allow-paid-service-plans")
+			}
+
+			runner.NewCmdRunner(cf.Cf(args...), context.shortTimeout).Run()
+			runner.NewCmdRunner(cf.Cf("create-org", context.organizationName), context.shortTimeout).Run()
+			runner.NewCmdRunner(cf.Cf("set-quota", context.organizationName, definition.Name), context.shortTimeout).Run()
+		})
+	}
 
 		if !context.config.UseExistingUser {
 			createUserCmd := cf.Cf("create-user", context.regularUserUsername, context.regularUserPassword)
@@ -122,10 +145,6 @@ func (context *ConfiguredContext) Setup() {
 				Expect(createUserCmd.Out).To(Say("scim_resource_already_exists"))
 			}
 		}
-
-		runner.NewCmdRunner(cf.Cf("create-org", context.organizationName), context.shortTimeout).Run()
-		runner.NewCmdRunner(cf.Cf("set-quota", context.organizationName, definition.Name), context.shortTimeout).Run()
-	})
 }
 
 func (context *ConfiguredContext) SetRunawayQuota() {
@@ -141,9 +160,14 @@ func (context *ConfiguredContext) Teardown() {
 			runner.NewCmdRunner(cf.Cf("delete-user", "-f", context.regularUserUsername), context.shortTimeout).Run()
 		}
 
-		if !context.isPersistent {
+		if !context.isPersistentApp && !context.isPersistentOrgAndSpace {
 			runner.NewCmdRunner(cf.Cf("delete-org", "-f", context.organizationName), context.shortTimeout).Run()
 			runner.NewCmdRunner(cf.Cf("delete-quota", "-f", context.quotaDefinitionName), context.shortTimeout).Run()
+		}
+
+		if context.isPersistentOrgAndSpace {
+			runner.NewCmdRunner(cf.Cf("t", "-o", context.organizationName), context.shortTimeout).Run()
+			runner.NewCmdRunner(cf.Cf("delete-space", "-f", context.spaceName), context.shortTimeout).Run()
 		}
 	})
 }

--- a/helpers/environment.go
+++ b/helpers/environment.go
@@ -17,6 +17,7 @@ type SuiteContext interface {
 
 	ShortTimeout() time.Duration
 	LongTimeout() time.Duration
+	IsPersistentOrgAndSpace() bool
 }
 
 type Environment struct {
@@ -32,9 +33,11 @@ func NewEnvironment(context SuiteContext) *Environment {
 func (e *Environment) Setup() {
 	e.context.Setup()
 
-	cf.AsUser(e.context.AdminUserContext(), e.context.ShortTimeout(), func() {
-		e.setUpSpaceWithUserAccess(e.context.RegularUserContext())
-	})
+	if !e.context.IsPersistentOrgAndSpace() {
+		cf.AsUser(e.context.AdminUserContext(), e.context.ShortTimeout(), func() {
+			e.setUpSpaceWithUserAccess(e.context.RegularUserContext())
+		})
+	}
 
 	e.originalCfHomeDir, e.currentCfHomeDir = cf.InitiateUserContext(e.context.RegularUserContext(), e.context.ShortTimeout())
 	cf.TargetSpace(e.context.RegularUserContext(), e.context.ShortTimeout())


### PR DESCRIPTION
Allows tests to run using a pre-created organization, space and quota based on settings in the integration.json file.  Some implementations of CF are not ideal for creating new organizations on the fly and this change allows testing under those conditions.