### PR TITLE
set CATS pwd to comply with optional CF policy

### DIFF
--- a/helpers/context.go
+++ b/helpers/context.go
@@ -46,7 +46,7 @@ func NewContext(config Config) *ConfiguredContext {
 	timeTag := time.Now().Format("2006_01_02-15h04m05.999s")
 
 	regUser := fmt.Sprintf("CATS-USER-%d-%s", node, timeTag)
-	regUserPass := "meow"
+	regUserPass := "meowHaiLoch4LeiChaht8aingei5Aek8oh"
 
 	if config.UseExistingUser {
 		regUser = config.ExistingUser

--- a/services/context.go
+++ b/services/context.go
@@ -86,7 +86,7 @@ func NewContext(config Config, prefix string) Context {
 		spaceName:        fmt.Sprintf("%s-SPACE-%d-%s", prefix, node, timeTag),
 
 		regularUserUsername: fmt.Sprintf("%s-USER-%d-%s", prefix, node, timeTag),
-		regularUserPassword: "meow",
+		regularUserPassword: "meowHaiLoch4LeiChaht8aingei5Aek8oh",
 
 		securityGroupName: fmt.Sprintf("%s-SECURITY_GROUP-%d-%s", prefix, node, timeTag),
 

--- a/services/context_test.go
+++ b/services/context_test.go
@@ -124,7 +124,7 @@ var _ = Describe("ConfiguredContext", func() {
 				createUserCall := FakeCfCalls[0]
 				Expect(createUserCall[0]).To(Equal("create-user"))
 				Expect(createUserCall[1]).To(MatchRegexp("fake-prefix-USER-\\d+-.*"))
-				Expect(createUserCall[2]).To(Equal("meow")) //why meow??
+				Expect(createUserCall[2]).To(Equal("meowHaiLoch4LeiChaht8aingei5Aek8oh")) // CF214 onwards allows pwd policy - so just in case no meow :(
 			})
 
 			It("creates a new quota with a unique name", func() {


### PR DESCRIPTION
CF v213 onwards allows an optional password policy.
To keep the tests from failing, they need to allow for a range
of possible settings. This should tide most over for now.

Signed-off-by: Sameer Mare <sameer.mare@atos.net>