### PR TITLE
Configuration helper validation fix.

### DIFF
--- a/helpers/config.go
+++ b/helpers/config.go
@@ -89,7 +89,7 @@ func LoadConfig() Config {
 		panic("missing configuration 'admin_user'")
 	}
 
-	if loadedConfig.ApiEndpoint == "" {
+	if loadedConfig.AdminPassword == "" {
 		panic("missing configuration 'admin_password'")
 	}
 


### PR DESCRIPTION
+ @dprotaso helped :P
Typo in validation meant AdminPassword was never validated.