### PR TITLE
Allow for configurable org/space/user

### DIFF
--- a/helpers/config.go
+++ b/helpers/config.go
@@ -68,6 +68,8 @@ type Config struct {
 	PythonBuildpackName     string `json:"python_buildpack_name"`
 	PhpBuildpackName        string `json:"php_buildpack_name"`
 	BinaryBuildpackName     string `json:"binary_buildpack_name"`
+
+	NamePrefix string `json:"name_prefix"`
 }
 
 var defaults = Config{
@@ -86,6 +88,8 @@ var defaults = Config{
 	BinaryBuildpackName:     "binary_buildpack",
 
 	ArtifactsDirectory: filepath.Join("..", "results"),
+
+	NamePrefix: "CATS",
 }
 
 func (c Config) ScaledTimeout(timeout time.Duration) time.Duration {

--- a/helpers/context.go
+++ b/helpers/context.go
@@ -45,7 +45,7 @@ func NewContext(config Config) *ConfiguredContext {
 	node := ginkgoconfig.GinkgoConfig.ParallelNode
 	timeTag := time.Now().Format("2006_01_02-15h04m05.999s")
 
-	regUser := fmt.Sprintf("CATS-USER-%d-%s", node, timeTag)
+	regUser := fmt.Sprintf("%s-USER-%d-%s", config.NamePrefix, node, timeTag)
 	regUserPass := "meow"
 
 	if config.UseExistingUser {
@@ -62,10 +62,10 @@ func NewContext(config Config) *ConfiguredContext {
 		shortTimeout: config.ScaledTimeout(1 * time.Minute),
 		longTimeout:  config.ScaledTimeout(5 * time.Minute),
 
-		quotaDefinitionName: fmt.Sprintf("CATS-QUOTA-%d-%s", node, timeTag),
+		quotaDefinitionName: fmt.Sprintf("%s-QUOTA-%d-%s", config.NamePrefix, node, timeTag),
 
-		organizationName: fmt.Sprintf("CATS-ORG-%d-%s", node, timeTag),
-		spaceName:        fmt.Sprintf("CATS-SPACE-%d-%s", node, timeTag),
+		organizationName: fmt.Sprintf("%s-ORG-%d-%s", config.NamePrefix, node, timeTag),
+		spaceName:        fmt.Sprintf("%s-SPACE-%d-%s", config.NamePrefix, node, timeTag),
 
 		regularUserUsername: regUser,
 		regularUserPassword: regUserPass,


### PR DESCRIPTION
This changes the hard coded "CATS" names to configurable items for those using this repo outside of CATS.
Signed-off-by: Paul Warren <paul.warren@emc.com>