### PR TITLE
Make SpaceName customisable

### DIFF
--- a/services/config.go
+++ b/services/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	SkipSSLValidation             bool    `json:"skip_ssl_validation"`
 	TimeoutScale                  float64 `json:"timeout_scale"`
 	OrgName                       string  `json:"org_name"`
+	SpaceName                     string  `json:"space_name"`
 	ConfigurableTestPassword      string  `json:"test_password"`
 }
 
@@ -55,6 +56,10 @@ func ValidateConfig(config *Config) error {
 		config.TimeoutScale = 1
 	} else if config.TimeoutScale < 0 {
 		return fmt.Errorf("Field 'timeout_scale' must not be negative (found %d)", config.TimeoutScale)
+	}
+
+	if config.SpaceName != "" && config.OrgName == "" {
+		return fmt.Errorf("Field 'space_name' cannot be set unless 'org_name' is also set")
 	}
 
 	return nil

--- a/services/config_test.go
+++ b/services/config_test.go
@@ -1,0 +1,75 @@
+package services_test
+
+import (
+	"github.com/cloudfoundry-incubator/cf-test-helpers/services"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ValidateConfig", func() {
+	Context("with a valid config", func() {
+		It("returns no error", func() {
+			validConfig := services.Config{
+				AppsDomain:    "bosh-lite.com",
+				ApiEndpoint:   "api.bosh-lite.com",
+				AdminUser:     "admin",
+				AdminPassword: "admin",
+			}
+
+			err := services.ValidateConfig(&validConfig)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("with an invalid config", func() {
+		It("returns an error if ApiEndpoint not set", func() {
+			invalidConfig := services.Config{
+				AppsDomain:    "bosh-lite.com",
+				AdminUser:     "admin",
+				AdminPassword: "admin",
+			}
+
+			err := services.ValidateConfig(&invalidConfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(MatchRegexp(`Field 'api' must not be empty`))
+		})
+
+		It("returns an error if AdminUser not set", func() {
+			invalidConfig := services.Config{
+				AppsDomain:    "bosh-lite.com",
+				ApiEndpoint:   "api.bosh-lite.com",
+				AdminPassword: "admin",
+			}
+
+			err := services.ValidateConfig(&invalidConfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(MatchRegexp(`Field 'admin_user' must not be empty`))
+		})
+
+		It("returns an error if AdminPassword not set", func() {
+			invalidConfig := services.Config{
+				AppsDomain:  "bosh-lite.com",
+				ApiEndpoint: "api.bosh-lite.com",
+				AdminUser:   "admin",
+			}
+
+			err := services.ValidateConfig(&invalidConfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(MatchRegexp(`Field 'admin_password' must not be empty`))
+		})
+
+		It("returns an error if custom SpaceName given without a custom OrgName", func() {
+			invalidConfig := services.Config{
+				AppsDomain:    "bosh-lite.com",
+				ApiEndpoint:   "api.bosh-lite.com",
+				AdminUser:     "admin",
+				AdminPassword: "admin",
+				SpaceName:     "my-cool-space",
+			}
+
+			err := services.ValidateConfig(&invalidConfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(MatchRegexp(`Field 'space_name' cannot be set unless 'org_name' is also set`))
+		})
+	})
+})


### PR DESCRIPTION
OrgName was already configurable by specifying an 'org_name' in your test config file -- this allows users to do the same with SpaceName.

We've added a guard to ensure you can't specify a SpaceName without an OrgName (because OrgNames are determined at runtime, so you wouldn't be able to pre-create a space in such an org).

Let us know if there are any questions!

@henryaj (Henry) and @chewymeister (Jon)
PCF Redis