### PR TITLE
Add dotnet core buildpack name to config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	PythonBuildpackName     string `json:"python_buildpack_name"`
 	PhpBuildpackName        string `json:"php_buildpack_name"`
 	BinaryBuildpackName     string `json:"binary_buildpack_name"`
+	DotnetCoreBuildpackName string `json:"dotnet_core_buildpack_name"`
 
 	IncludeApps                       bool `json:"include_apps"`
 	IncludeBackendCompatiblity        bool `json:"include_backend_compatibility"`
@@ -94,6 +95,7 @@ var defaults = Config{
 	PythonBuildpackName:     "python_buildpack",
 	PhpBuildpackName:        "php_buildpack",
 	BinaryBuildpackName:     "binary_buildpack",
+	DotnetCoreBuildpackName: "dotnet_core_buildpack",
 
 	IncludeApps:                true,
 	IncludeBackendCompatiblity: true,


### PR DESCRIPTION
The dotnet core buildpack is being added to cf-release and hence CATS. This PR adds the appropriate changes to support CATS.

[#131997427]

Signed-off-by: Sam Smith sesmith177@gmail.com
