### PR TITLE
Always strip the Expect header from `curl` requests

### DIFF
--- a/helpers/internal/curl.go
+++ b/helpers/internal/curl.go
@@ -8,6 +8,7 @@ import (
 
 func Curl(cmdStarter internal.Starter, skipSsl bool, args ...string) *gexec.Session {
 	curlArgs := append([]string{"-s"}, args...)
+	curlArgs = append([]string{"-H", "Expect:"}, curlArgs...)
 	if skipSsl {
 		curlArgs = append([]string{"-k"}, curlArgs...)
 	}

--- a/helpers/internal/curl_test.go
+++ b/helpers/internal/curl_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Curl", func() {
 		Expect(session).To(gexec.Exit(0))
 		Expect(session.Out).To(Say("HTTP/1.1 200 OK"))
 		Expect(starter.CalledWith[0].Executable).To(Equal("curl"))
-		Expect(starter.CalledWith[0].Args).To(ConsistOf("-I", "-s", "http://example.com"))
+		Expect(starter.CalledWith[0].Args).To(ConsistOf("-H", "Expect:", "-I", "-s", "http://example.com"))
 	})
 
 	Context("when the starter returns an error", func() {


### PR DESCRIPTION
Some infrastructures (notable Google Cloud Platform when using an HTTP
load balancer) do not allow 100 Continue responses. `curl` will add
'Expect: 100-Continue` to requests that include bodies, prompting
servers to respond with 100 Continue. By unsetting the header, we
prevent 100 Continue responses, allowing the responses to move through
the load balancer.

Note: This is a fixed version of #26. We didn't have access to the original remote to push this commit there.

Signed-off-by: Dan Wendorf <dwendorf@pivotal.io>