### PR TITLE
Support usage of existing organization

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,9 @@ type Config struct {
 
 	ConfigurableTestPassword string `json:"test_password"`
 
+	UseExistingOrganization bool   `json:"use_existing_organization"`
+	ExistingOrganization    string `json:"existing_organization"`
+
 	PersistentAppHost      string `json:"persistent_app_host"`
 	PersistentAppSpace     string `json:"persistent_app_space"`
 	PersistentAppOrg       string `json:"persistent_app_org"`
@@ -271,6 +274,14 @@ func (c *Config) GetAdminUser() string {
 
 func (c *Config) GetAdminPassword() string {
 	return c.AdminPassword
+}
+
+func (c *Config) GetUseExistingOrganization() bool {
+	return c.UseExistingOrganization
+}
+
+func (c *Config) GetExistingOrganization() string {
+	return c.ExistingOrganization
 }
 
 func (c *Config) GetApiEndpoint() string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -56,6 +56,8 @@ var _ = Describe("Config", func() {
 
 	It("should have the right defaults", func() {
 		Expect(config.IncludeApps).To(BeTrue())
+		Expect(config.UseExistingOrganization).To(BeFalse())
+		Expect(config.ExistingOrganization).To(BeEmpty())
 		Expect(config.DefaultTimeout).To(Equal(30))
 		Expect(config.DefaultTimeoutDuration()).To(Equal(30 * time.Second))
 		Expect(config.CfPushTimeout).To(Equal(2))

--- a/workflowhelpers/internal/space.go
+++ b/workflowhelpers/internal/space.go
@@ -16,6 +16,7 @@ type TestSpace struct {
 	organizationName                     string
 	spaceName                            string
 	isPersistent                         bool
+	isExistingOrganization               bool
 	QuotaDefinitionTotalMemoryLimit      string
 	QuotaDefinitionInstanceMemoryLimit   string
 	QuotaDefinitionRoutesLimit           string
@@ -32,6 +33,8 @@ type spaceConfig interface {
 	GetPersistentAppOrg() string
 	GetPersistentAppQuotaName() string
 	GetNamePrefix() string
+	GetUseExistingOrganization() bool
+	GetExistingOrganization() string
 }
 
 type Space interface {
@@ -42,12 +45,14 @@ type Space interface {
 }
 
 func NewRegularTestSpace(cfg spaceConfig, quotaLimit string) *TestSpace {
+	organizationName, isExistingOrganization := organizationName(cfg)
 	return NewBaseTestSpace(
 		generator.PrefixedRandomName(cfg.GetNamePrefix(), "SPACE"),
-		generator.PrefixedRandomName(cfg.GetNamePrefix(), "ORG"),
+		organizationName,
 		generator.PrefixedRandomName(cfg.GetNamePrefix(), "QUOTA"),
 		quotaLimit,
 		false,
+		isExistingOrganization,
 		cfg.GetScaledTimeout(1*time.Minute),
 		commandstarter.NewCommandStarter(),
 	)
@@ -60,13 +65,14 @@ func NewPersistentAppTestSpace(cfg spaceConfig) *TestSpace {
 		cfg.GetPersistentAppQuotaName(),
 		"10G",
 		true,
+		true,
 		cfg.GetScaledTimeout(1*time.Minute),
 		commandstarter.NewCommandStarter(),
 	)
 	return baseTestSpace
 }
 
-func NewBaseTestSpace(spaceName, organizationName, quotaDefinitionName, quotaDefinitionTotalMemoryLimit string, isPersistent bool, timeout time.Duration, cmdStarter internal.Starter) *TestSpace {
+func NewBaseTestSpace(spaceName, organizationName, quotaDefinitionName, quotaDefinitionTotalMemoryLimit string, isPersistent bool, isExistingOrganization bool, timeout time.Duration, cmdStarter internal.Starter) *TestSpace {
 	testSpace := &TestSpace{
 		QuotaDefinitionName:                  quotaDefinitionName,
 		QuotaDefinitionTotalMemoryLimit:      quotaDefinitionTotalMemoryLimit,
@@ -80,6 +86,7 @@ func NewBaseTestSpace(spaceName, organizationName, quotaDefinitionName, quotaDef
 		CommandStarter:                       cmdStarter,
 		Timeout:                              timeout,
 		isPersistent:                         isPersistent,
+		isExistingOrganization:               isExistingOrganization,
 	}
 	return testSpace
 
@@ -100,8 +107,10 @@ func (ts *TestSpace) Create() {
 	createQuota := internal.Cf(ts.CommandStarter, args...)
 	EventuallyWithOffset(1, createQuota, ts.Timeout).Should(Exit(0))
 
-	createOrg := internal.Cf(ts.CommandStarter, "create-org", ts.organizationName)
-	EventuallyWithOffset(1, createOrg, ts.Timeout).Should(Exit(0))
+	if !ts.isExistingOrganization {
+		createOrg := internal.Cf(ts.CommandStarter, "create-org", ts.organizationName)
+		EventuallyWithOffset(1, createOrg, ts.Timeout).Should(Exit(0))
+	}
 
 	setQuota := internal.Cf(ts.CommandStarter, "set-quota", ts.organizationName, ts.QuotaDefinitionName)
 	EventuallyWithOffset(1, setQuota, ts.Timeout).Should(Exit(0))
@@ -111,9 +120,16 @@ func (ts *TestSpace) Create() {
 }
 
 func (ts *TestSpace) Destroy() {
-	deleteOrg := internal.Cf(ts.CommandStarter, "delete-org", "-f", ts.organizationName)
-	EventuallyWithOffset(1, deleteOrg, ts.Timeout).Should(Exit(0))
+	if ts.isExistingOrganization {
+		setDefaultQuota := internal.Cf(ts.CommandStarter, "set-quota", ts.organizationName, "default")
+		EventuallyWithOffset(1, setDefaultQuota, ts.Timeout).Should(Exit(0))
 
+		deleteSpace := internal.Cf(ts.CommandStarter, "delete-space", "-f", "-o", ts.organizationName, ts.spaceName)
+		EventuallyWithOffset(1, deleteSpace, ts.Timeout).Should(Exit(0))
+	} else {
+		deleteOrg := internal.Cf(ts.CommandStarter, "delete-org", "-f", ts.organizationName)
+		EventuallyWithOffset(1, deleteOrg, ts.Timeout).Should(Exit(0))
+	}
 	deleteQuota := internal.Cf(ts.CommandStarter, "delete-quota", "-f", ts.QuotaDefinitionName)
 	EventuallyWithOffset(1, deleteQuota, ts.Timeout).Should(Exit(0))
 }
@@ -134,4 +150,14 @@ func (ts *TestSpace) SpaceName() string {
 
 func (ts *TestSpace) ShouldRemain() bool {
 	return ts.isPersistent
+}
+
+func organizationName(cfg spaceConfig) (string, bool) {
+	if cfg.GetUseExistingOrganization() {
+		if len(cfg.GetExistingOrganization()) == 0 {
+			panic("existing organization name must be specified")
+		}
+		return cfg.GetExistingOrganization(), true
+	}
+	return generator.PrefixedRandomName(cfg.GetNamePrefix(), "ORG"), false
 }

--- a/workflowhelpers/internal/space.go
+++ b/workflowhelpers/internal/space.go
@@ -154,9 +154,7 @@ func (ts *TestSpace) ShouldRemain() bool {
 
 func organizationName(cfg spaceConfig) (string, bool) {
 	if cfg.GetUseExistingOrganization() {
-		if len(cfg.GetExistingOrganization()) == 0 {
-			panic("existing organization name must be specified")
-		}
+		Expect(cfg.GetExistingOrganization()).To(Not(BeEmpty()), "existing_organization must be specified")
 		return cfg.GetExistingOrganization(), true
 	}
 	return generator.PrefixedRandomName(cfg.GetNamePrefix(), "ORG"), false

--- a/workflowhelpers/internal/space_test.go
+++ b/workflowhelpers/internal/space_test.go
@@ -95,10 +95,11 @@ var _ = Describe("TestSpace", func() {
 						UseExistingOrganization: true,
 					}
 				})
-				It("panics", func() {
-					Expect(func() {
+				It("fails with a ginkgo error", func() {
+					failures := InterceptGomegaFailures(func() {
 						NewRegularTestSpace(&cfg, quotaLimit)
-					}).Should(Panic())
+					})
+					Expect(failures).To(ContainElement(ContainSubstring("existing_organization must be specified")))
 				})
 			})
 		})

--- a/workflowhelpers/test_suite_setup.go
+++ b/workflowhelpers/test_suite_setup.go
@@ -26,6 +26,8 @@ type testSuiteConfig interface {
 	GetShouldKeepUser() bool
 	GetUseExistingUser() bool
 	GetAdminUser() string
+	GetUseExistingOrganization() bool
+	GetExistingOrganization() string
 	GetSkipSSLValidation() bool
 	GetNamePrefix() string
 }


### PR DESCRIPTION
Allows users to specify an existing organization to use rather than creating a new organization.

For consistency with existing properties (`use_existing_user`) it adds two new properties:
* `use_existing_organization`
* ` existing_organization`

One issue we hit is that when tearing down the test quota it must be first unset from the organization. Here we have assumed that the organization previously had the `default` quota.