### PR TITLE
Remove GetOrganizationName()

### DIFF
--- a/workflowhelpers/test_suite_setup.go
+++ b/workflowhelpers/test_suite_setup.go
@@ -110,10 +110,6 @@ func NewBaseTestSuiteSetup(config testSuiteConfig, testSpace internal.Space, tes
 	}
 }
 
-func (testSetup ReproducibleTestSuiteSetup) GetOrganizationName() string {
-	return testSetup.TestSpace.OrganizationName()
-}
-
 func (testSetup ReproducibleTestSuiteSetup) ShortTimeout() time.Duration {
 	return testSetup.shortTimeout
 }

--- a/workflowhelpers/test_suite_setup_test.go
+++ b/workflowhelpers/test_suite_setup_test.go
@@ -75,12 +75,6 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 			setup := NewBaseTestSuiteSetup(&cfg, testSpace, testUser, regularUserContext, adminUserContext)
 			Expect(setup.TestSpace).To(Equal(testSpace))
 		})
-
-		It("sets the OrganizationName to the testSpace's organiation name", func() {
-			setup := NewBaseTestSuiteSetup(&cfg, testSpace, testUser, regularUserContext, adminUserContext)
-
-			Expect(setup.GetOrganizationName()).To(Equal(testSpace.OrganizationName()))
-		})
 	})
 
 	Describe("NewTestSuiteSetup", func() {


### PR DESCRIPTION
Seems like the only usage for it in CATS was in the Isolation_segments suite. We are now using `UserContext.Org` instead.