### PR TITLE
Space Workflow Helper: when using an existing org, do not create/delete quota

### DIFF
--- a/workflowhelpers/internal/space.go
+++ b/workflowhelpers/internal/space.go
@@ -89,7 +89,6 @@ func NewBaseTestSpace(spaceName, organizationName, quotaDefinitionName, quotaDef
 		isExistingOrganization:               isExistingOrganization,
 	}
 	return testSpace
-
 }
 
 func (ts *TestSpace) Create() {
@@ -104,16 +103,16 @@ func (ts *TestSpace) Create() {
 		ts.QuotaDefinitionAllowPaidServicesFlag,
 	}
 
-	createQuota := internal.Cf(ts.CommandStarter, args...)
-	EventuallyWithOffset(1, createQuota, ts.Timeout).Should(Exit(0))
-
 	if !ts.isExistingOrganization {
+		createQuota := internal.Cf(ts.CommandStarter, args...)
+		EventuallyWithOffset(1, createQuota, ts.Timeout).Should(Exit(0))
+
 		createOrg := internal.Cf(ts.CommandStarter, "create-org", ts.organizationName)
 		EventuallyWithOffset(1, createOrg, ts.Timeout).Should(Exit(0))
-	}
 
-	setQuota := internal.Cf(ts.CommandStarter, "set-quota", ts.organizationName, ts.QuotaDefinitionName)
-	EventuallyWithOffset(1, setQuota, ts.Timeout).Should(Exit(0))
+		setQuota := internal.Cf(ts.CommandStarter, "set-quota", ts.organizationName, ts.QuotaDefinitionName)
+		EventuallyWithOffset(1, setQuota, ts.Timeout).Should(Exit(0))
+	}
 
 	createSpace := internal.Cf(ts.CommandStarter, "create-space", "-o", ts.organizationName, ts.spaceName)
 	EventuallyWithOffset(1, createSpace, ts.Timeout).Should(Exit(0))
@@ -121,17 +120,15 @@ func (ts *TestSpace) Create() {
 
 func (ts *TestSpace) Destroy() {
 	if ts.isExistingOrganization {
-		setDefaultQuota := internal.Cf(ts.CommandStarter, "set-quota", ts.organizationName, "default")
-		EventuallyWithOffset(1, setDefaultQuota, ts.Timeout).Should(Exit(0))
-
 		deleteSpace := internal.Cf(ts.CommandStarter, "delete-space", "-f", "-o", ts.organizationName, ts.spaceName)
 		EventuallyWithOffset(1, deleteSpace, ts.Timeout).Should(Exit(0))
 	} else {
 		deleteOrg := internal.Cf(ts.CommandStarter, "delete-org", "-f", ts.organizationName)
 		EventuallyWithOffset(1, deleteOrg, ts.Timeout).Should(Exit(0))
+
+		deleteQuota := internal.Cf(ts.CommandStarter, "delete-quota", "-f", ts.QuotaDefinitionName)
+		EventuallyWithOffset(1, deleteQuota, ts.Timeout).Should(Exit(0))
 	}
-	deleteQuota := internal.Cf(ts.CommandStarter, "delete-quota", "-f", ts.QuotaDefinitionName)
-	EventuallyWithOffset(1, deleteQuota, ts.Timeout).Should(Exit(0))
 }
 
 func (ts *TestSpace) OrganizationName() string {

--- a/workflowhelpers/internal/space_test.go
+++ b/workflowhelpers/internal/space_test.go
@@ -173,52 +173,71 @@ var _ = Describe("TestSpace", func() {
 			testSpace = NewBaseTestSpace(spaceName, orgName, quotaName, quotaLimit, isPersistent, isExistingOrganization, timeout, fakeStarter)
 		})
 
-		It("creates a quota", func() {
-			testSpace.Create()
-			Expect(len(fakeStarter.CalledWith)).To(BeNumerically(">", 0))
-			Expect(fakeStarter.CalledWith[0].Executable).To(Equal("cf"))
-			Expect(fakeStarter.CalledWith[0].Args).To(Equal([]string{
-				"create-quota", testSpace.QuotaDefinitionName,
-				"-m", testSpace.QuotaDefinitionTotalMemoryLimit,
-				"-i", testSpace.QuotaDefinitionInstanceMemoryLimit,
-				"-r", testSpace.QuotaDefinitionRoutesLimit,
-				"-a", testSpace.QuotaDefinitionAppInstanceLimit,
-				"-s", testSpace.QuotaDefinitionServiceInstanceLimit,
-				testSpace.QuotaDefinitionAllowPaidServicesFlag,
-			}))
-		})
+		Context("when the organization name is not specified", func() {
+			It("creates a quota", func() {
+				testSpace.Create()
+				Expect(len(fakeStarter.CalledWith)).To(BeNumerically(">", 0))
+				Expect(fakeStarter.CalledWith[0].Executable).To(Equal("cf"))
+				Expect(fakeStarter.CalledWith[0].Args).To(Equal([]string{
+					"create-quota", testSpace.QuotaDefinitionName,
+					"-m", testSpace.QuotaDefinitionTotalMemoryLimit,
+					"-i", testSpace.QuotaDefinitionInstanceMemoryLimit,
+					"-r", testSpace.QuotaDefinitionRoutesLimit,
+					"-a", testSpace.QuotaDefinitionAppInstanceLimit,
+					"-s", testSpace.QuotaDefinitionServiceInstanceLimit,
+					testSpace.QuotaDefinitionAllowPaidServicesFlag,
+				}))
+			})
 
-		It("creates an org", func() {
-			testSpace.Create()
-			Expect(len(fakeStarter.CalledWith)).To(BeNumerically(">", 1))
-			Expect(fakeStarter.CalledWith[1].Executable).To(Equal("cf"))
-			Expect(fakeStarter.CalledWith[1].Args).To(Equal([]string{"create-org", testSpace.OrganizationName()}))
+			It("creates an org", func() {
+				testSpace.Create()
+				Expect(len(fakeStarter.CalledWith)).To(BeNumerically(">", 1))
+				Expect(fakeStarter.CalledWith[1].Executable).To(Equal("cf"))
+				Expect(fakeStarter.CalledWith[1].Args).To(Equal([]string{
+					"create-org",
+					testSpace.OrganizationName()
+				}))
+			})
+
+			It("sets the quota for the org", func() {
+				testSpace.Create()
+				Expect(len(fakeStarter.CalledWith)).To(BeNumerically(">", 2))
+				Expect(fakeStarter.CalledWith[2].Executable).To(Equal("cf"))
+				Expect(fakeStarter.CalledWith[2].Args).To(Equal([]string{
+					"set-quota",
+					testSpace.OrganizationName(),
+					testSpace.QuotaDefinitionName
+				}))
+			})
+
+			It("creates a space", func() {
+				testSpace.Create()
+				Expect(len(fakeStarter.CalledWith)).To(BeNumerically(">", 3))
+				Expect(fakeStarter.CalledWith[3].Executable).To(Equal("cf"))
+				Expect(fakeStarter.CalledWith[3].Args).To(Equal([]string{
+					"create-space",
+					"-o",
+					testSpace.OrganizationName(),
+					testSpace.SpaceName()
+				}))
+			})
 		})
 
 		Context("when the config specifies that an existing organization should be used", func() {
 			BeforeEach(func() {
 				isExistingOrganization = true
 			})
-			It("does not create the org", func() {
+
+			It("creates the space, but not the org or the quota, and does not set the quota", func() {
 				testSpace.Create()
-				for _, calls := range fakeStarter.CalledWith {
-					Expect(calls.Args).ToNot(ContainElement("create-org"))
-				}
+				Expect(len(fakeStarter.CalledWith).To(Equal(1))
+			  Expect(fakeStarter.CalledWith[0]).To(Equal([]string{
+					"create-space",
+					"-o",
+					testSpace.organizationName,
+					testSpace.spaceName,
+				}))
 			})
-		})
-
-		It("sets quota", func() {
-			testSpace.Create()
-			Expect(len(fakeStarter.CalledWith)).To(BeNumerically(">", 2))
-			Expect(fakeStarter.CalledWith[2].Executable).To(Equal("cf"))
-			Expect(fakeStarter.CalledWith[2].Args).To(Equal([]string{"set-quota", testSpace.OrganizationName(), testSpace.QuotaDefinitionName}))
-		})
-
-		It("create space", func() {
-			testSpace.Create()
-			Expect(len(fakeStarter.CalledWith)).To(BeNumerically(">", 3))
-			Expect(fakeStarter.CalledWith[3].Executable).To(Equal("cf"))
-			Expect(fakeStarter.CalledWith[3].Args).To(Equal([]string{"create-space", "-o", testSpace.OrganizationName(), testSpace.SpaceName()}))
 		})
 
 		Describe("failure cases", func() {
@@ -271,7 +290,6 @@ var _ = Describe("TestSpace", func() {
 			Context("when 'cf set-quota' times out", testTimeoutCase(2))
 			Context("when 'cf create-space' times out", testTimeoutCase(3))
 		})
-
 	})
 
 	Describe("Destroy", func() {
@@ -324,24 +342,12 @@ var _ = Describe("TestSpace", func() {
 			BeforeEach(func() {
 				isExistingOrganization = true
 			})
-			It("does not delete the org", func() {
+
+			It("deletes the space, but does not delete the org or quota", func() {
 				testSpace.Destroy()
-				for _, calls := range fakeStarter.CalledWith {
-					Expect(calls.Args).ToNot(ContainElement("delete-org"))
-				}
-			})
-			It("restores the default quota", func() {
-				testSpace.Destroy()
-				Expect(len(fakeStarter.CalledWith)).To(BeNumerically(">", 0))
+				Expect(len(fakeStarter.CalledWith).To(Equal(1))
 				Expect(fakeStarter.CalledWith[0].Executable).To(Equal("cf"))
 				Expect(fakeStarter.CalledWith[0].Args).To(Equal(
-					[]string{"set-quota", testSpace.OrganizationName(), "default"}))
-			})
-			It("deletes the space", func() {
-				testSpace.Destroy()
-				Expect(len(fakeStarter.CalledWith)).To(BeNumerically(">", 1))
-				Expect(fakeStarter.CalledWith[1].Executable).To(Equal("cf"))
-				Expect(fakeStarter.CalledWith[1].Args).To(Equal(
 					[]string{"delete-space", "-f", "-o", testSpace.OrganizationName(), testSpace.SpaceName()}))
 			})
 		})

--- a/workflowhelpers/internal/space_test.go
+++ b/workflowhelpers/internal/space_test.go
@@ -195,7 +195,7 @@ var _ = Describe("TestSpace", func() {
 				Expect(fakeStarter.CalledWith[1].Executable).To(Equal("cf"))
 				Expect(fakeStarter.CalledWith[1].Args).To(Equal([]string{
 					"create-org",
-					testSpace.OrganizationName()
+					testSpace.OrganizationName(),
 				}))
 			})
 
@@ -206,7 +206,7 @@ var _ = Describe("TestSpace", func() {
 				Expect(fakeStarter.CalledWith[2].Args).To(Equal([]string{
 					"set-quota",
 					testSpace.OrganizationName(),
-					testSpace.QuotaDefinitionName
+					testSpace.QuotaDefinitionName,
 				}))
 			})
 
@@ -218,7 +218,7 @@ var _ = Describe("TestSpace", func() {
 					"create-space",
 					"-o",
 					testSpace.OrganizationName(),
-					testSpace.SpaceName()
+					testSpace.SpaceName(),
 				}))
 			})
 		})
@@ -230,12 +230,13 @@ var _ = Describe("TestSpace", func() {
 
 			It("creates the space, but not the org or the quota, and does not set the quota", func() {
 				testSpace.Create()
-				Expect(len(fakeStarter.CalledWith).To(Equal(1))
-			  Expect(fakeStarter.CalledWith[0]).To(Equal([]string{
+				Expect(len(fakeStarter.CalledWith)).To(BeNumerically("==", 1))
+				Expect(fakeStarter.CalledWith[0].Executable).To(Equal("cf"))
+				Expect(fakeStarter.CalledWith[0].Args).To(Equal([]string{
 					"create-space",
 					"-o",
-					testSpace.organizationName,
-					testSpace.spaceName,
+					testSpace.OrganizationName(),
+					testSpace.SpaceName(),
 				}))
 			})
 		})
@@ -345,7 +346,7 @@ var _ = Describe("TestSpace", func() {
 
 			It("deletes the space, but does not delete the org or quota", func() {
 				testSpace.Destroy()
-				Expect(len(fakeStarter.CalledWith).To(Equal(1))
+				Expect(len(fakeStarter.CalledWith)).To(BeNumerically("==", 1))
 				Expect(fakeStarter.CalledWith[0].Executable).To(Equal("cf"))
 				Expect(fakeStarter.CalledWith[0].Args).To(Equal(
 					[]string{"delete-space", "-f", "-o", testSpace.OrganizationName(), testSpace.SpaceName()}))


### PR DESCRIPTION
- In the Create and Delete functions of the Space Workflow Helper, when an org is specified, assume that the quota for this org has already been set, and do not create or delete quotas in setup and teardown
- This is to avoid the following situation: If an org is specified, and we were to allow the helper to create/delete the quota, it would have to restore the org's quota to the state prior to the test run; this can fail if tests crash, resulting in an unintentional quota change. 