### PR TITLE
Updated default test user password

### DIFF
--- a/workflowhelpers/internal/user.go
+++ b/workflowhelpers/internal/user.go
@@ -41,7 +41,7 @@ func NewTestUser(config userConfig, cmdStarter internal.Starter) *TestUser {
 
 	var regUser, regUserPass string
 	regUser = fmt.Sprintf("%s-USER-%d-%s", config.GetNamePrefix(), node, timeTag)
-	regUserPass = "meow"
+	regUserPass = "Meoooooooooow!1"
 
 	if config.GetUseExistingUser() {
 		regUser = config.GetExistingUser()

--- a/workflowhelpers/internal/user_test.go
+++ b/workflowhelpers/internal/user_test.go
@@ -36,7 +36,7 @@ var _ = Describe("User", func() {
 		It("has a random username and hard-coded password", func() {
 			user := NewTestUser(cfg, &fakes.FakeCmdStarter{})
 			Expect(user.Username()).To(MatchRegexp("UNIT-TESTS-USER-[0-9]+-.*"))
-			Expect(user.Password()).To(Equal("meow"))
+			Expect(user.Password()).To(Equal("Meoooooooooow!1"))
 		})
 
 		Context("when the config specifies that an existing user should be used", func() {

--- a/workflowhelpers/test_suite_setup_test.go
+++ b/workflowhelpers/test_suite_setup_test.go
@@ -129,7 +129,7 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 			It("has a regular TestUser", func() {
 				setup := NewTestSuiteSetup(&cfg)
 				Expect(setup.RegularUserContext().TestUser.Username()).To(MatchRegexp("UNIT-TESTS-USER-[0-9]+-.*"))
-				Expect(setup.RegularUserContext().TestUser.Password()).To(Equal("meow"))
+				Expect(setup.RegularUserContext().TestUser.Password()).To(Equal("Meoooooooooow!1"))
 			})
 
 			It("uses the api endpoint and SkipSSLValidation from the config", func() {
@@ -206,7 +206,7 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 			It("has a regular TestUser", func() {
 				setup := NewPersistentAppTestSuiteSetup(&cfg)
 				Expect(setup.RegularUserContext().TestUser.Username()).To(MatchRegexp("UNIT-TESTS-USER-[0-9]+-.*"))
-				Expect(setup.RegularUserContext().TestUser.Password()).To(Equal("meow"))
+				Expect(setup.RegularUserContext().TestUser.Password()).To(Equal("Meoooooooooow!1"))
 			})
 
 			It("uses the api endpoint and SkipSSLValidation from the config", func() {
@@ -274,7 +274,7 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 			It("has a regular TestUser", func() {
 				setup := NewSmokeTestSuiteSetup(&cfg)
 				Expect(setup.RegularUserContext().TestUser.Username()).To(MatchRegexp("UNIT-TESTS-USER-[0-9]+-.*"))
-				Expect(setup.RegularUserContext().TestUser.Password()).To(Equal("meow"))
+				Expect(setup.RegularUserContext().TestUser.Password()).To(Equal("Meoooooooooow!1"))
 			})
 
 			It("configures a smoke test setup", func() {
@@ -345,7 +345,7 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 			It("has a regular TestUser", func() {
 				setup := NewRunawayAppTestSuiteSetup(&cfg)
 				Expect(setup.RegularUserContext().TestUser.Username()).To(MatchRegexp("UNIT-TESTS-USER-[0-9]+-.*"))
-				Expect(setup.RegularUserContext().TestUser.Password()).To(Equal("meow"))
+				Expect(setup.RegularUserContext().TestUser.Password()).To(Equal("Meoooooooooow!1"))
 			})
 
 			It("uses the api endpoint and SkipSSLValidation from the config", func() {


### PR DESCRIPTION
Password now:
* is 15 characters long
* has one uppercase character
* has one digit
* has one special character

In Pivotal CloudCache we create a user using cf-test-helpers in our smoke tests. A customer has enforced secure passwords in their pcf environment so this test fails. By making the password more secure by the above definition, we will unblock this customer.

Signed-off-by: Peter Tran <ptran@pivotal.io>