### PR TITLE
Improve random identifier in random name helper

### DIFF
--- a/generator/generator_suite_test.go
+++ b/generator/generator_suite_test.go
@@ -1,0 +1,13 @@
+package generator_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestGenerator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Generator Suite")
+}

--- a/generator/random_name.go
+++ b/generator/random_name.go
@@ -1,19 +1,21 @@
 package generator
 
 import (
+	"crypto/rand"
+	"fmt"
 	"strconv"
 
-	uuid "github.com/nu7hatch/gouuid"
 	"github.com/onsi/ginkgo/config"
 )
 
 func randomName() string {
-	guid, err := uuid.NewV4()
+	b := make([]byte, 8)
+	_, err := rand.Read(b)
 	if err != nil {
 		panic(err)
 	}
 
-	return guid.String()[0:20]
+	return fmt.Sprintf("%x", b)
 }
 
 func PrefixedRandomName(prefixName, resourceName string) string {

--- a/generator/random_name_test.go
+++ b/generator/random_name_test.go
@@ -1,0 +1,30 @@
+package generator_test
+
+import (
+	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RandomName", func() {
+	It("generates a short name", func() {
+		name := generator.PrefixedRandomName("", "")
+		Expect(len(name)).To(BeNumerically("<=", 24))
+	})
+
+	It("generates a name starting with the prefix", func() {
+		name := generator.PrefixedRandomName("PREFIX", "APP")
+		Expect(name).To(HavePrefix("PREFIX"))
+	})
+
+	It("generates a name containing the resource", func() {
+		name := generator.PrefixedRandomName("PREFIX", "APP")
+		Expect(name).To(ContainSubstring("APP"))
+	})
+
+	It("generates a name ending in 16 hexadecimal digits", func() {
+		name := generator.PrefixedRandomName("PREFIX", "APP")
+		Expect(name).To(MatchRegexp(".*-[0-9a-f]{16}$"))
+	})
+})


### PR DESCRIPTION
The PrefixedRandomName helper generates names of the form "CATS-1-ORG-6e0b3df3-c397-4643-4", where the string of hexadecimal digits comes from truncating a v4 UUID at 20 characters. This change simplifies the helper to make its random identifier simply a string of 16 hexadecimal digits, so that random names are instead of the form "CATS-1-ORG-6e0b3df3c3974643". This consolidated identifier will be easier to find in aggregated test and component logs and will not be confused with other UUIDs internal to Cloud Foundry.

This change also removes the dependency on the third-party UUID library in favor of the equivalent calls to the standard library.