### PR TITLE
Now honors UseExistingUser flag from config

### DIFF
--- a/workflowhelpers/test_suite_setup.go
+++ b/workflowhelpers/test_suite_setup.go
@@ -71,8 +71,9 @@ func NewTestSuiteSetup(config testSuiteConfig) *ReproducibleTestSuiteSetup {
 	shortTimeout := config.GetScaledTimeout(1 * time.Minute)
 	regularUserContext := NewUserContext(config.GetApiEndpoint(), testUser, testSpace, config.GetSkipSSLValidation(), shortTimeout)
 	adminUserContext := NewUserContext(config.GetApiEndpoint(), adminUser, nil, config.GetSkipSSLValidation(), shortTimeout)
+	skipUserCreation := config.GetUseExistingUser()
 
-	return NewBaseTestSuiteSetup(config, testSpace, testUser, regularUserContext, adminUserContext, false)
+	return NewBaseTestSuiteSetup(config, testSpace, testUser, regularUserContext, adminUserContext, skipUserCreation)
 }
 
 func NewSmokeTestSuiteSetup(config testSuiteConfig) *ReproducibleTestSuiteSetup {
@@ -103,8 +104,9 @@ func NewPersistentAppTestSuiteSetup(config testSuiteConfig) *ReproducibleTestSui
 	shortTimeout := config.GetScaledTimeout(1 * time.Minute)
 	regularUserContext := NewUserContext(config.GetApiEndpoint(), testUser, testSpace, config.GetSkipSSLValidation(), shortTimeout)
 	adminUserContext := NewUserContext(config.GetApiEndpoint(), adminUser, nil, config.GetSkipSSLValidation(), shortTimeout)
+	skipUserCreation := config.GetUseExistingUser()
 
-	testSuiteSetup := NewBaseTestSuiteSetup(config, testSpace, testUser, regularUserContext, adminUserContext, false)
+	testSuiteSetup := NewBaseTestSuiteSetup(config, testSpace, testUser, regularUserContext, adminUserContext, skipUserCreation)
 	testSuiteSetup.isPersistent = true
 
 	return testSuiteSetup
@@ -118,8 +120,9 @@ func NewRunawayAppTestSuiteSetup(config testSuiteConfig) *ReproducibleTestSuiteS
 	shortTimeout := config.GetScaledTimeout(1 * time.Minute)
 	regularUserContext := NewUserContext(config.GetApiEndpoint(), testUser, testSpace, config.GetSkipSSLValidation(), shortTimeout)
 	adminUserContext := NewUserContext(config.GetApiEndpoint(), adminUser, nil, config.GetSkipSSLValidation(), shortTimeout)
+	skipUserCreation := config.GetUseExistingUser()
 
-	return NewBaseTestSuiteSetup(config, testSpace, testUser, regularUserContext, adminUserContext, false)
+	return NewBaseTestSuiteSetup(config, testSpace, testUser, regularUserContext, adminUserContext, skipUserCreation)
 }
 
 func NewBaseTestSuiteSetup(config testSuiteConfig, testSpace internal.Space, testUser remoteResource, regularUserContext, adminUserContext UserContext, skipUserCreation bool) *ReproducibleTestSuiteSetup {

--- a/workflowhelpers/test_suite_setup_test.go
+++ b/workflowhelpers/test_suite_setup_test.go
@@ -85,6 +85,7 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 
 	Describe("NewTestSuiteSetup", func() {
 		var cfg config.Config
+		var existingUserCfg config.Config
 		var useExistingUser bool
 		var existingUser, existingUserPassword string
 		var configurableTestPassword string
@@ -112,6 +113,12 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 				ApiEndpoint:              apiEndpoint,
 				AdminUser:                "admin",
 				AdminPassword:            "admin-password",
+			}
+
+			existingUserCfg = config.Config{
+				UseExistingUser:          true,
+				ExistingUser:             "existing-user",
+				ExistingUserPassword:     "existing-user-password",
 			}
 		})
 
@@ -161,10 +168,18 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 			Expect(adminUserContext.Timeout).To(Equal(cfg.GetScaledTimeout(1 * time.Minute)))
 		})
 
+		It("uses the existing user", func() {
+			setup := NewTestSuiteSetup(&existingUserCfg)
+			regularUserContext := setup.RegularUserContext()
+			Expect(setup.SkipUserCreation).To(Equal(existingUserCfg.UseExistingUser))
+			Expect(regularUserContext.TestUser.Username()).To(Equal(existingUserCfg.ExistingUser))
+			Expect(regularUserContext.TestUser.Password()).To(Equal(existingUserCfg.ExistingUserPassword))
+		})
 	})
 
 	Describe("NewPersistentAppTestSuiteSetup", func() {
 		var cfg config.Config
+		var existingUserCfg config.Config
 		var orgName, quotaName, spaceName string
 		var apiEndpoint string
 		var skipSSLValidation bool
@@ -188,6 +203,12 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 				SkipSSLValidation:      skipSSLValidation,
 				AdminUser:              "admin",
 				AdminPassword:          "admin-password",
+			}
+
+			existingUserCfg = config.Config{
+				UseExistingUser:          true,
+				ExistingUser:             "existing-user",
+				ExistingUserPassword:     "existing-user-password",
 			}
 		})
 
@@ -235,6 +256,14 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 			Expect(adminUserContext.TestSpace).To(BeNil())
 			Expect(adminUserContext.SkipSSLValidation).To(Equal(cfg.SkipSSLValidation))
 			Expect(adminUserContext.Timeout).To(Equal(cfg.GetScaledTimeout(1 * time.Minute)))
+		})
+
+		It("uses the existing user", func() {
+			setup := NewPersistentAppTestSuiteSetup(&existingUserCfg)
+			regularUserContext := setup.RegularUserContext()
+			Expect(setup.SkipUserCreation).To(Equal(existingUserCfg.UseExistingUser))
+			Expect(regularUserContext.TestUser.Username()).To(Equal(existingUserCfg.ExistingUser))
+			Expect(regularUserContext.TestUser.Password()).To(Equal(existingUserCfg.ExistingUserPassword))
 		})
 	})
 
@@ -309,6 +338,7 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 
 	Describe("NewRunawayAppTestSetup", func() {
 		var cfg config.Config
+		var existingUserCfg config.Config
 		var apiEndpoint string
 		var skipSSLValidation bool
 
@@ -325,6 +355,12 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 				SkipSSLValidation: skipSSLValidation,
 				AdminUser:         "admin",
 				AdminPassword:     "admin-password",
+			}
+
+			existingUserCfg = config.Config{
+				UseExistingUser:          true,
+				ExistingUser:             "existing-user",
+				ExistingUserPassword:     "existing-user-password",
 			}
 		})
 
@@ -374,6 +410,14 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 			Expect(adminUserContext.TestSpace).To(BeNil())
 			Expect(adminUserContext.SkipSSLValidation).To(Equal(cfg.SkipSSLValidation))
 			Expect(adminUserContext.Timeout).To(Equal(cfg.GetScaledTimeout(1 * time.Minute)))
+		})
+
+		It("uses the existing user", func() {
+			setup := NewRunawayAppTestSuiteSetup(&existingUserCfg)
+			regularUserContext := setup.RegularUserContext()
+			Expect(setup.SkipUserCreation).To(Equal(existingUserCfg.UseExistingUser))
+			Expect(regularUserContext.TestUser.Username()).To(Equal(existingUserCfg.ExistingUser))
+			Expect(regularUserContext.TestUser.Password()).To(Equal(existingUserCfg.ExistingUserPassword))
 		})
 	})
 


### PR DESCRIPTION
I discovered that when CATS is configured to use an existing user, it still tries to create the user in UAA. When UAA is backed by LDAP, this results in two users with the same username but different origins. This fix corrects the issue by making test_suite_setup.go honor the UseExistingUser flag from the config.