### PR TITLE
Increase entropy of generated user password

### DIFF
--- a/workflowhelpers/internal/user.go
+++ b/workflowhelpers/internal/user.go
@@ -111,7 +111,7 @@ func generateUserName(prefix string) string {
 	return fmt.Sprintf("%s-USER-%d-%s", prefix, node, timeTag)
 }
 
-// The key think that makes a password secure is the _entropy_ that comes from a
+// The key thing that makes a password secure is the _entropy_ that comes from a
 // generator of true random numbers.  But many password rules require a mixure
 // of cases, numbers and special characters.  Here we meet these rules by starting
 // the password with the required upper/lower case, number and special.  Then we make

--- a/workflowhelpers/internal/user.go
+++ b/workflowhelpers/internal/user.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"time"
 
@@ -36,16 +38,14 @@ type adminuserConfig interface {
 }
 
 func NewTestUser(config userConfig, cmdStarter internal.Starter) *TestUser {
-	node := ginkgoconfig.GinkgoConfig.ParallelNode
-	timeTag := time.Now().Format("2006_01_02-15h04m05.999s")
-
 	var regUser, regUserPass string
-	regUser = fmt.Sprintf("%s-USER-%d-%s", config.GetNamePrefix(), node, timeTag)
-	regUserPass = "meow"
 
 	if config.GetUseExistingUser() {
 		regUser = config.GetExistingUser()
 		regUserPass = config.GetExistingUserPassword()
+	} else {
+		regUser = generateUserName(config.GetNamePrefix())
+		regUserPass = generatePassword()
 	}
 
 	if config.GetConfigurableTestPassword() != "" {
@@ -103,4 +103,28 @@ func combineOutputAndRedact(session *Session, redactor internal.Redactor) *Buffe
 	stderr := redactor.Redact(string(session.Err.Contents()))
 
 	return BufferWithBytes(append([]byte(stdout), []byte(stderr)...))
+}
+
+func generateUserName(prefix string) string {
+	node := ginkgoconfig.GinkgoConfig.ParallelNode
+	timeTag := time.Now().Format("2006_01_02-15h04m05.999s")
+	return fmt.Sprintf("%s-USER-%d-%s", prefix, node, timeTag)
+}
+
+// The key think that makes a password secure is the _entropy_ that comes from a
+// generator of true random numbers.  But many password rules require a mixure
+// of cases, numbers and special characters.  Here we meet these rules by starting
+// the password with the required upper/lower case, number and special.  Then we make
+// it secure by adding truly random characters.
+func generatePassword() string {
+	const randomBytesLength = 16
+	encoding := base64.RawURLEncoding
+
+	randomBytes := make([]byte, encoding.DecodedLen(randomBytesLength))
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		panic(fmt.Errorf("Could not generate random password: %s", err.Error()))
+	}
+
+	return "A0a!" + encoding.EncodeToString(randomBytes)
 }

--- a/workflowhelpers/internal/user_test.go
+++ b/workflowhelpers/internal/user_test.go
@@ -33,10 +33,16 @@ var _ = Describe("User", func() {
 			}
 		})
 
-		It("has a random username and hard-coded password", func() {
+		It("has a username and password", func() {
 			user := NewTestUser(cfg, &fakes.FakeCmdStarter{})
 			Expect(user.Username()).To(MatchRegexp("UNIT-TESTS-USER-[0-9]+-.*"))
-			Expect(user.Password()).To(Equal("meow"))
+			Expect(len(user.Password())).To(Equal(20))
+		})
+
+		It("has a unique random password", func() {
+			password1 := NewTestUser(cfg, &fakes.FakeCmdStarter{}).Password()
+			password2 := NewTestUser(cfg, &fakes.FakeCmdStarter{}).Password()
+			Expect(password1).ToNot(Equal(password2))
 		})
 
 		Context("when the config specifies that an existing user should be used", func() {

--- a/workflowhelpers/test_suite_setup_test.go
+++ b/workflowhelpers/test_suite_setup_test.go
@@ -136,7 +136,7 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 			It("has a regular TestUser", func() {
 				setup := NewTestSuiteSetup(&cfg)
 				Expect(setup.RegularUserContext().TestUser.Username()).To(MatchRegexp("UNIT-TESTS-USER-[0-9]+-.*"))
-				Expect(setup.RegularUserContext().TestUser.Password()).To(Equal("meow"))
+				Expect(len(setup.RegularUserContext().TestUser.Password())).To(Equal(20))
 			})
 
 			It("uses the api endpoint and SkipSSLValidation from the config", func() {
@@ -226,7 +226,7 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 			It("has a regular TestUser", func() {
 				setup := NewPersistentAppTestSuiteSetup(&cfg)
 				Expect(setup.RegularUserContext().TestUser.Username()).To(MatchRegexp("UNIT-TESTS-USER-[0-9]+-.*"))
-				Expect(setup.RegularUserContext().TestUser.Password()).To(Equal("meow"))
+				Expect(len(setup.RegularUserContext().TestUser.Password())).To(Equal(20))
 			})
 
 			It("uses the api endpoint and SkipSSLValidation from the config", func() {
@@ -302,7 +302,7 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 			It("has a regular TestUser", func() {
 				setup := NewSmokeTestSuiteSetup(&cfg)
 				Expect(setup.RegularUserContext().TestUser.Username()).To(MatchRegexp("UNIT-TESTS-USER-[0-9]+-.*"))
-				Expect(setup.RegularUserContext().TestUser.Password()).To(Equal("meow"))
+				Expect(len(setup.RegularUserContext().TestUser.Password())).To(Equal(20))
 			})
 
 			It("configures a smoke test setup", func() {
@@ -380,7 +380,7 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 			It("has a regular TestUser", func() {
 				setup := NewRunawayAppTestSuiteSetup(&cfg)
 				Expect(setup.RegularUserContext().TestUser.Username()).To(MatchRegexp("UNIT-TESTS-USER-[0-9]+-.*"))
-				Expect(setup.RegularUserContext().TestUser.Password()).To(Equal("meow"))
+				Expect(len(setup.RegularUserContext().TestUser.Password())).To(Equal(20))
 			})
 
 			It("uses the api endpoint and SkipSSLValidation from the config", func() {


### PR DESCRIPTION
- Currently the password is always `meow` which is a little insecure and
does not meet password rules
- It is now a 20 character password, where 16 characters are random, and
the others are added to meet common password rules, such as on PWS.

Signed-off-by: Michal Kuratczyk <mkuratczyk@pivotal.io>