### PR TITLE
always retry cf auth!

### DIFF
--- a/internal/fakes/fake_starter.go
+++ b/internal/fakes/fake_starter.go
@@ -16,7 +16,7 @@ type callToStartMethod struct {
 	Reporter   internal.Reporter
 }
 
-type startMethodStub struct {
+type StartMethodStub struct {
 	Output    string
 	Stderr    string
 	Err       error
@@ -26,14 +26,14 @@ type startMethodStub struct {
 
 type FakeCmdStarter struct {
 	CalledWith        []callToStartMethod
-	ToReturn          []startMethodStub
+	ToReturn          []StartMethodStub
 	TotalCallsToStart int
 }
 
 func NewFakeCmdStarter() *FakeCmdStarter {
 	return &FakeCmdStarter{
 		CalledWith: []callToStartMethod{},
-		ToReturn:   make([]startMethodStub, 10),
+		ToReturn:   make([]StartMethodStub, 10),
 	}
 }
 

--- a/workflowhelpers/internal/cf_auth.go
+++ b/workflowhelpers/internal/cf_auth.go
@@ -3,12 +3,39 @@ package internal
 import (
 	"github.com/cloudfoundry-incubator/cf-test-helpers/internal"
 	"github.com/onsi/gomega/gexec"
+	"time"
+	. "github.com/onsi/gomega"
 )
 
-func CfAuth(cmdStarter internal.Starter, reporter internal.Reporter, user string, password string) *gexec.Session {
-	auth, err := cmdStarter.Start(reporter, "cf", "auth", user, password)
-	if err != nil {
-		panic(err)
+func CfAuth(cmdStarter internal.Starter, reporter internal.Reporter, user string, password string, ) *gexec.Session {
+	var auth *gexec.Session
+	var err error
+
+	retries := 2
+	for i := 1; i <= retries; i++ {
+		auth, err = cmdStarter.Start(reporter, "cf", "auth", user, password)
+		if err != nil {
+			panic(err)
+		}
+
+		if i < retries {
+			// retry timeouts if not final retry
+			failures := InterceptGomegaFailures(func() {
+				auth.Wait(5)
+			})
+			if len(failures) != 0 {
+				continue
+			}
+		} else {
+			auth.Wait(5)
+		}
+
+		returnVal := auth.ExitCode()
+		if returnVal == 0 {
+			return auth
+		}
+		time.Sleep(1 * time.Second)
 	}
+
 	return auth
 }

--- a/workflowhelpers/user_context.go
+++ b/workflowhelpers/user_context.go
@@ -96,7 +96,7 @@ func (uc UserContext) Login() {
 	redactingReporter := internal.NewRedactingReporter(ginkgo.GinkgoWriter, redactor)
 
 	session = workflowhelpersinternal.CfAuth(uc.CommandStarter, redactingReporter, uc.TestUser.Username(), uc.TestUser.Password())
-	EventuallyWithOffset(1, session, uc.Timeout).Should(Exit(0), cliErrorMessage(session))
+	Expect(session).To(Exit(0), cliErrorMessage(session))
 }
 
 func (uc UserContext) SetCfHomeDir() (string, string) {


### PR DESCRIPTION
Hi!

This PR hardcodes a retry after 1 second of waiting for all `cf auth` commands... It also hardcodes an unchangeable 5-second timeout for the `cf auth` invocation.

Unit tests for new functionality are added, currently all unit tests pass.

We have already merged this fork into the tests for our product. They seem to be working fine so far.

We call the `Setup()` function from ReproducibleTestSetup ~200 times every time our pipeline run, so we should see in a few days if it causes anything weird. 

Hopefully this can be merged in soon if it fixes the cf auth flakes!

best
David