### PR TITLE
add AddExistingUserToExistingSpace config to skip the creation of space role when existing user and existing space are specified

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,8 +32,9 @@ type Config struct {
 	UseExistingOrganization bool   `json:"use_existing_organization"`
 	ExistingOrganization    string `json:"existing_organization"`
 
-	UseExistingSpace bool   `json:"use_existing_space"`
-	ExistingSpace    string `json:"existing_space"`
+	AddExistingUserToExistingSpace bool   `json:"add_existing_user_to_existing_space"`
+	UseExistingSpace               bool   `json:"use_existing_space"`
+	ExistingSpace                  string `json:"existing_space"`
 
 	SkipSSLValidation bool   `json:"skip_ssl_validation"`
 	Backend           string `json:"backend"`
@@ -96,17 +97,18 @@ var defaults = Config{
 	PhpBuildpackName:        "php_buildpack",
 	BinaryBuildpackName:     "binary_buildpack",
 
-	IncludeApps:                true,
-	IncludeBackendCompatiblity: true,
-	IncludeDetect:              true,
-	IncludeDocker:              true,
-	IncludeInternetDependent:   true,
-	IncludeRouteServices:       true,
-	IncludeRouting:             true,
-	IncludeSecurityGroups:      true,
-	IncludeServices:            true,
-	IncludeSsh:                 true,
-	IncludeV3:                  true,
+	IncludeApps:                    true,
+	IncludeBackendCompatiblity:     true,
+	IncludeDetect:                  true,
+	IncludeDocker:                  true,
+	IncludeInternetDependent:       true,
+	IncludeRouteServices:           true,
+	IncludeRouting:                 true,
+	IncludeSecurityGroups:          true,
+	IncludeServices:                true,
+	IncludeSsh:                     true,
+	IncludeV3:                      true,
+	AddExistingUserToExistingSpace: true,
 
 	DefaultTimeout:               30,
 	CfPushTimeout:                2,
@@ -238,6 +240,10 @@ func (c *Config) GetNamePrefix() string {
 
 func (c *Config) GetUseExistingUser() bool {
 	return c.UseExistingUser
+}
+
+func (c *Config) GetAddExistingUserToExistingSpace() bool {
+	return c.AddExistingUserToExistingSpace
 }
 
 func (c *Config) GetUseExistingSpace() bool {

--- a/workflowhelpers/internal/space.go
+++ b/workflowhelpers/internal/space.go
@@ -31,6 +31,7 @@ type TestSpace struct {
 type SpaceAndOrgConfig interface {
 	GetUseExistingOrganization() bool
 	GetUseExistingSpace() bool
+	GetAddExistingUserToExistingSpace() bool
 	GetExistingOrganization() string
 	GetExistingSpace() string
 }

--- a/workflowhelpers/test_suite_setup.go
+++ b/workflowhelpers/test_suite_setup.go
@@ -42,7 +42,8 @@ type ReproducibleTestSuiteSetup struct {
 
 	SkipSSLValidation bool
 
-	SkipUserCreation bool
+	SkipUserCreation      bool
+	SkipSpaceRoleCreation bool
 
 	originalCfHomeDir string
 	currentCfHomeDir  string
@@ -107,9 +108,10 @@ func NewBaseTestSuiteSetup(config testSuiteConfig, testSpace internal.Space, tes
 		regularUserContext: regularUserContext,
 		adminUserContext:   adminUserContext,
 
-		SkipUserCreation: skipUserCreation,
-		TestSpace:        testSpace,
-		TestUser:         testUser,
+		SkipUserCreation:      skipUserCreation,
+		SkipSpaceRoleCreation: !config.GetAddExistingUserToExistingSpace(),
+		TestSpace:             testSpace,
+		TestUser:              testUser,
 	}
 }
 
@@ -131,7 +133,7 @@ func (testSetup *ReproducibleTestSuiteSetup) Setup() {
 		if !testSetup.SkipUserCreation {
 			testSetup.TestUser.Create()
 		}
-		if !testSetup.RegularUserContext().UseClientCredentials {
+		if !testSetup.SkipSpaceRoleCreation && !testSetup.RegularUserContext().UseClientCredentials {
 			testSetup.regularUserContext.AddUserToSpace()
 		}
 	})

--- a/workflowhelpers/test_suite_setup_test.go
+++ b/workflowhelpers/test_suite_setup_test.go
@@ -311,7 +311,9 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 				TestUser:       fakeAdminUserValues,
 				Timeout:        2 * time.Second,
 			}
-			cfg = config.Config{}
+			cfg = config.Config{
+				AddExistingUserToExistingSpace: true,
+			}
 		})
 
 		JustBeforeEach(func() {


### PR DESCRIPTION
Can we add this configuration item `AddExistingUserToExistingSpace` ?
So that the `set-space-role` step can be skipped when the existing user is already the space admin/develop/auditor of the existing space.
Because the `set-space-role` command is restricted in some of the cf environments.
And we are relying on `cf-test-helpers` to test our service.