### PR TITLE
Allow instantiating a CF command with provided STDIN buffer.

### DIFF
--- a/cf/cf.go
+++ b/cf/cf.go
@@ -1,6 +1,8 @@
 package cf
 
 import (
+	"io"
+
 	"github.com/cloudfoundry-incubator/cf-test-helpers/commandstarter"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/internal"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/silentcommandstarter"
@@ -28,4 +30,15 @@ var CfRedact = func(stringToRedact string, args ...string) *gexec.Session {
 	redactingReporter = internal.NewRedactingReporter(ginkgo.GinkgoWriter, redactor)
 
 	return internal.CfWithCustomReporter(cmdStarter, redactingReporter, args...)
+}
+
+// CfWithStdin can be used to prepare arbitrary terminal input from the user in the tests.
+// Here is an example of how it can be used:
+//
+// inputConfirmingPrompt := bytes.NewBufferString("yes\n")
+// session := cf.CfWithStdin(inputConfirmingPrompt, "update-service", "my-service", "--upgrade")
+// Eventually(session).Should(Exit(0))
+var CfWithStdin = func(stdin io.Reader, args ...string) *gexec.Session {
+	cmdStarter := commandstarter.NewCommandStarterWithStdin(stdin)
+	return internal.Cf(cmdStarter, args...)
 }

--- a/commandstarter/command_starter.go
+++ b/commandstarter/command_starter.go
@@ -1,6 +1,7 @@
 package commandstarter
 
 import (
+	"io"
 	"os/exec"
 	"time"
 
@@ -10,14 +11,22 @@ import (
 )
 
 type CommandStarter struct {
+	stdin io.Reader
 }
 
 func NewCommandStarter() *CommandStarter {
 	return &CommandStarter{}
 }
 
+func NewCommandStarterWithStdin(stdin io.Reader) *CommandStarter {
+	return &CommandStarter{
+		stdin: stdin,
+	}
+}
+
 func (r *CommandStarter) Start(reporter internal.Reporter, executable string, args ...string) (*gexec.Session, error) {
 	cmd := exec.Command(executable, args...)
+	cmd.Stdin = r.stdin
 	reporter.Report(time.Now(), cmd)
 
 	return gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)


### PR DESCRIPTION
The use case that we have in ODB (https://github.com/pivotal-cf/on-demand-service-broker) system tests is that we need to send some input from the user to confirm the `cf update-service service-name --upgrade` command (`--force` flag is not released yet, so we can't use it).

This adds a new flavor of `cf.Cf(…)` function: `cf.CfWithStdin(stdin, …)`. Appropriate changes to the command starter are included as well.