### PR TITLE
don't skip space role creation on new spaces

### DIFF
--- a/workflowhelpers/test_suite_setup.go
+++ b/workflowhelpers/test_suite_setup.go
@@ -109,7 +109,7 @@ func NewBaseTestSuiteSetup(config testSuiteConfig, testSpace internal.Space, tes
 		adminUserContext:   adminUserContext,
 
 		SkipUserCreation:      skipUserCreation,
-		SkipSpaceRoleCreation: !config.GetAddExistingUserToExistingSpace() && skipUserCreation,
+		SkipSpaceRoleCreation: !config.GetAddExistingUserToExistingSpace() && !config.GetUseExistingSpace() && skipUserCreation,
 		TestSpace:             testSpace,
 		TestUser:              testUser,
 	}

--- a/workflowhelpers/test_suite_setup.go
+++ b/workflowhelpers/test_suite_setup.go
@@ -109,7 +109,7 @@ func NewBaseTestSuiteSetup(config testSuiteConfig, testSpace internal.Space, tes
 		adminUserContext:   adminUserContext,
 
 		SkipUserCreation:      skipUserCreation,
-		SkipSpaceRoleCreation: !config.GetAddExistingUserToExistingSpace() && !config.GetUseExistingSpace() && skipUserCreation,
+		SkipSpaceRoleCreation: !config.GetAddExistingUserToExistingSpace() && config.GetUseExistingSpace() && skipUserCreation,
 		TestSpace:             testSpace,
 		TestUser:              testUser,
 	}


### PR DESCRIPTION
fixes #46 
When not using an existing space, but using an existing user, we need to add the user to the space.